### PR TITLE
fix(timezone): compute dynamic resource status in IST

### DIFF
--- a/app/(main)/buildings/[buildingId]/floors/[floorId]/actions.ts
+++ b/app/(main)/buildings/[buildingId]/floors/[floorId]/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/utils/supabase/server'
 import { calculateDynamicStatus, type Booking } from '@/lib/dynamic-status'
+import { getISTDateString } from '@/lib/ist'
 
 export async function getBuildingDetails(buildingId: string) {
   const supabase = await createClient()
@@ -184,7 +185,7 @@ export async function getResourcesWithStatus(floorId: string) {
       .select('resource_id, start_date, end_date, start_time, end_time, status, weekdays')
       .in('resource_id', resourceIds)
       .eq('status', 'approved')  // Only approved bookings affect resource status
-      .gte('end_date', new Date().toISOString().split('T')[0])
+      .gte('end_date', getISTDateString())
 
     if (bookingsError) {
       console.error('Error fetching bookings:', bookingsError)

--- a/app/(main)/buildings/[buildingId]/floors/[floorId]/resources/[resourceId]/actions.ts
+++ b/app/(main)/buildings/[buildingId]/floors/[floorId]/resources/[resourceId]/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createClient } from '@/utils/supabase/server'
+import { getISTDateString } from '@/lib/ist'
 import { calculateDynamicStatus } from '@/lib/dynamic-status'
 
 export async function getBuildingDetails(buildingId: string) {
@@ -164,7 +165,7 @@ export async function getResourceWithDetails(resourceId: string) {
       .select('start_date, end_date, start_time, end_time, status, weekdays')
       .eq('resource_id', resourceId)
       .eq('status', 'approved')  // Only approved bookings affect resource status
-      .gte('end_date', new Date().toISOString().split('T')[0])
+      .gte('end_date', getISTDateString())
 
     if (allBookingsError) {
       console.error('Error fetching bookings for status:', allBookingsError)
@@ -295,7 +296,7 @@ export async function getResourceBookings(resourceId: string) {
         class_name
       `)
       .eq('resource_id', resourceId)
-      .gte('end_date', new Date().toISOString().split('T')[0]) // Only show current and future bookings
+      .gte('end_date', getISTDateString()) // Only show current and future bookings
       .order('start_date', { ascending: true })
       .order('start_time', { ascending: true })
 

--- a/app/(main)/buildings/[buildingId]/floors/[floorId]/resources/[resourceId]/components/BookingForm.tsx
+++ b/app/(main)/buildings/[buildingId]/floors/[floorId]/resources/[resourceId]/components/BookingForm.tsx
@@ -8,6 +8,7 @@ import { TimePicker } from '@/components/ui/time-picker'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { createBooking } from '../actions'
+import { getISTDateString } from '@/lib/ist'
 import React from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
@@ -94,8 +95,8 @@ export default function BookingForm({ resourceId }: BookingFormProps) {
       // Create FormData for the server action
       const formData = new FormData()
       formData.append('resourceId', resourceId)
-      formData.append('startDate', startDate.toISOString().split('T')[0])
-      formData.append('endDate', endDate.toISOString().split('T')[0])
+  formData.append('startDate', getISTDateString(startDate))
+  formData.append('endDate', getISTDateString(endDate))
       formData.append('startTime', startTime)
       formData.append('endTime', endTime)
       formData.append('reason', reason)

--- a/app/(main)/buildings/[buildingId]/resources/[resourceId]/actions.ts
+++ b/app/(main)/buildings/[buildingId]/resources/[resourceId]/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createClient } from '@/utils/supabase/server'
+import { getISTDateString } from '@/lib/ist'
 import { calculateDynamicStatus } from '@/lib/dynamic-status'
 
 export async function getBuildingDetails(buildingId: string) {
@@ -164,7 +165,7 @@ export async function getResourceWithDetails(resourceId: string) {
       .select('start_date, end_date, start_time, end_time, status, weekdays')
       .eq('resource_id', resourceId)
       .eq('status', 'approved')  // Only approved bookings affect resource status
-      .gte('end_date', new Date().toISOString().split('T')[0])
+      .gte('end_date', getISTDateString())
 
     if (allBookingsError) {
       console.error('Error fetching bookings for status:', allBookingsError)
@@ -295,7 +296,7 @@ export async function getResourceBookings(resourceId: string) {
         class_name
       `)
       .eq('resource_id', resourceId)
-      .gte('end_date', new Date().toISOString().split('T')[0]) // Only show current and future bookings
+      .gte('end_date', getISTDateString()) // Only show current and future bookings (IST)
       .order('start_date', { ascending: true })
       .order('start_time', { ascending: true })
 

--- a/app/(main)/buildings/[buildingId]/resources/[resourceId]/components/BookingForm.tsx
+++ b/app/(main)/buildings/[buildingId]/resources/[resourceId]/components/BookingForm.tsx
@@ -8,6 +8,7 @@ import { TimePicker } from '@/components/ui/time-picker'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { createBooking } from '../actions'
+import { getISTDateString } from '@/lib/ist'
 import React from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
@@ -94,8 +95,8 @@ export default function BookingForm({ resourceId }: BookingFormProps) {
       // Create FormData for the server action
       const formData = new FormData()
       formData.append('resourceId', resourceId)
-      formData.append('startDate', startDate.toISOString().split('T')[0])
-      formData.append('endDate', endDate.toISOString().split('T')[0])
+  formData.append('startDate', getISTDateString(startDate))
+  formData.append('endDate', getISTDateString(endDate))
       formData.append('startTime', startTime)
       formData.append('endTime', endTime)
       formData.append('reason', reason)

--- a/app/(main)/buildings/[buildingId]/resources/actions.ts
+++ b/app/(main)/buildings/[buildingId]/resources/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createClient } from '@/utils/supabase/server'
+import { getISTDateString } from '@/lib/ist'
 import { calculateDynamicStatus, type Booking } from '@/lib/dynamic-status'
 
 export async function getBuildingDetails(buildingId: string) {
@@ -78,7 +79,7 @@ export async function getBuildingResources(buildingId: string) {
       .select('resource_id, start_date, end_date, start_time, end_time, status, weekdays')
       .in('resource_id', resourceIds)
       .eq('status', 'approved')  // Only approved bookings affect resource status
-      .gte('end_date', new Date().toISOString().split('T')[0])
+  .gte('end_date', getISTDateString())
 
     if (bookingsError) {
       console.error('Error fetching bookings:', bookingsError)
@@ -228,7 +229,7 @@ export async function searchBuildingResources(buildingId: string, searchTerm?: s
       .select('resource_id, start_date, end_date, start_time, end_time, status, weekdays')
       .in('resource_id', resourceIds)
       .eq('status', 'approved')  // Only approved bookings affect resource status
-      .gte('end_date', new Date().toISOString().split('T')[0])
+  .gte('end_date', getISTDateString())
 
     if (bookingsError) {
       console.error('Error fetching bookings:', bookingsError)

--- a/app/(main)/resources/actions.ts
+++ b/app/(main)/resources/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createClient } from '@/utils/supabase/server'
+import { getISTDateString } from '@/lib/ist'
 import { redirect } from 'next/navigation'
 import { calculateDynamicStatus, type Booking } from '@/lib/dynamic-status'
 
@@ -168,7 +169,7 @@ export async function getPaginatedResources(
       )
     }
 
-    const { data: resources, error, count } = await query
+  const { data: resources, error, count } = await query
 
     if (error) {
       console.error('Error fetching paginated resources:', error)
@@ -188,7 +189,7 @@ export async function getPaginatedResources(
         .select('resource_id, start_date, end_date, start_time, end_time, status, weekdays')
         .in('resource_id', resourceIds)
         .eq('status', 'approved')
-        .gte('end_date', new Date().toISOString().split('T')[0])
+        .gte('end_date', getISTDateString())
 
       if (bookingsError) {
         console.error('Error fetching bookings:', bookingsError)

--- a/lib/ist.ts
+++ b/lib/ist.ts
@@ -1,0 +1,58 @@
+// Deterministic IST helpers using Intl.formatToParts
+// Avoid parsing localized strings with `new Date(localizedString)` which is
+// implementation-dependent. Use formatToParts to extract numeric components
+// in the Asia/Kolkata timezone and build ISO-like strings or Date objects.
+
+function getISTParts(d = new Date()) {
+  const dtf = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Kolkata',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+
+  const parts = dtf.formatToParts(d)
+  const map: Record<string, string> = {}
+  for (const p of parts) {
+    if (p.type !== 'literal') map[p.type] = p.value
+  }
+
+  return {
+    year: Number(map.year),
+    month: Number(map.month),
+    day: Number(map.day),
+    hour: Number(map.hour),
+    minute: Number(map.minute),
+    second: Number(map.second),
+  }
+}
+
+export function getISTDateObj(d = new Date()): Date {
+  const { year, month, day, hour, minute, second } = getISTParts(d)
+  // Build an ISO string with +05:30 offset so Date parses to the exact IST
+  // instant represented by the wall-clock time.
+  const iso = `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:${String(second).padStart(2, '0')}+05:30`
+  return new Date(iso)
+}
+
+export function getISTDateString(d = new Date()): string {
+  const { year, month, day } = getISTParts(d)
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+export function getISTTimeString(d = new Date()): string {
+  const { hour, minute } = getISTParts(d)
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+}
+
+// Day of week in project's convention: 1=Sunday, 2=Monday, ..., 7=Saturday
+export function getISTDayOfWeek(d = new Date()): number {
+  const { year, month, day } = getISTParts(d)
+  // Weekday for the calendar date is invariant; compute via UTC date.
+  const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay() // 0..6
+  return weekday + 1
+}


### PR DESCRIPTION
Replace brittle IST helper with a deterministic Intl.formatToParts implementation.

- Use `getISTDateString()`, `getISTTimeString()`, `getISTDayOfWeek()` for dynamic status calculations.
- Update server booking queries to filter with `getISTDateString()` so current/future booking selection is IST-based.
- Update booking forms to submit IST date strings.
- Normalize time comparisons to seconds and handle overnight spans (supports HH:MM / HH:MM:SS).
- Keep audit timestamps (`approved_at`) stored as UTC (TIMESTAMPTZ).