### PR TITLE
feat(approval): add profile approval workflow and booking guards

### DIFF
--- a/app/(main)/buildings/[buildingId]/floors/[floorId]/resources/[resourceId]/actions.ts
+++ b/app/(main)/buildings/[buildingId]/floors/[floorId]/resources/[resourceId]/actions.ts
@@ -228,6 +228,22 @@ export async function createBooking(formData: FormData) {
       return { error: 'User not authenticated' }
     }
 
+    // Check that the user's profile is approved
+    const { data: currentProfile, error: profileError } = await supabase
+      .from('profiles')
+      .select('approved')
+      .eq('id', user.id)
+      .single()
+
+    if (profileError) {
+      console.error('Error fetching user profile:', profileError)
+      return { error: 'Failed to verify user profile' }
+    }
+
+    if (!currentProfile || currentProfile.approved !== true) {
+      return { error: 'Account pending approval' }
+    }
+
     // Verify that the resource exists and is active
     const { data: resource, error: resourceError } = await supabase
       .from('resources')

--- a/app/(main)/buildings/[buildingId]/resources/[resourceId]/actions.ts
+++ b/app/(main)/buildings/[buildingId]/resources/[resourceId]/actions.ts
@@ -228,6 +228,22 @@ export async function createBooking(formData: FormData) {
       return { error: 'User not authenticated' }
     }
 
+    // Check that the user's profile is approved
+    const { data: currentProfile, error: profileError } = await supabase
+      .from('profiles')
+      .select('approved')
+      .eq('id', user.id)
+      .single()
+
+    if (profileError) {
+      console.error('Error fetching user profile:', profileError)
+      return { error: 'Failed to verify user profile' }
+    }
+
+    if (!currentProfile || currentProfile.approved !== true) {
+      return { error: 'Account pending approval' }
+    }
+
     // Verify that the resource exists and is active
     const { data: resource, error: resourceError } = await supabase
       .from('resources')

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -31,6 +31,10 @@ CREATE TABLE profiles (
   cabin VARCHAR(50),
   cubicle VARCHAR(50),
   workstation VARCHAR(50),
+  -- Approval workflow fields
+  approved BOOLEAN NOT NULL DEFAULT false,
+  approved_by UUID,
+  approved_at TIMESTAMP WITH TIME ZONE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 


### PR DESCRIPTION
- add `approved`, `approved_by`, `approved_at` to `profiles` (DB schema)
- admin approve/unapprove actions + UI (`app/admin/actions.ts`, `app/admin/users/page.tsx`)
- server-side booking guard in resource `createBooking` actions
- client gating in `BookingForm` components (refresh & copy-contact UX)
- surface approver name in booking cards; use deterministic IST handling for dates/times